### PR TITLE
Switch from std::sync::mpsc to tokio::sync::mpsc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
-authors       = ["imranmaj <49664304+imranmaj@users.noreply.github.com>"]
-categories    = [
+authors = ["imranmaj <49664304+imranmaj@users.noreply.github.com>"]
+categories = [
     "asynchronous",
     "network-programming",
     "web-programming",
     "web-programming::websocket",
 ]
-description   = "A WebSocket client implementation."
+description = "A WebSocket client implementation."
 documentation = "http://docs.rs/websockets"
-edition       = "2018"
-keywords      = ["websocket", "websockets", "async", "tokio", "io"]
-license       = "MIT"
-name          = "websockets"
-readme        = "README.md"
-repository    = "https://github.com/imranmaj/websockets"
-version       = "0.4.0"
+edition = "2018"
+keywords = ["websocket", "websockets", "async", "tokio", "io"]
+license = "MIT"
+name = "websockets"
+readme = "README.md"
+repository = "https://github.com/imranmaj/websockets"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 base64           = "0.12.3"
+flume            = "0.10.7"
 futures          = "0.3.5"
 native-tls       = "0.2.6"
 rand             = "0.7.3"
@@ -27,7 +28,9 @@ rand_chacha      = "0.2.2"
 regex            = "1.3.9"
 sha-1            = "0.9.1"
 thiserror        = "1.0.20"
-tokio            = { version = "1.9", features = ["full"] }
-tokio-native-tls = "0.3"
+tokio            = { version = "1.9", features = ["net", "io-util"] }
+tokio-native-tls = "0.3.0"
 url              = "2.1.1"
-flume            = "0.10"
+
+[dev-dependencies]
+tokio = { version = "1.9", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license       = "MIT"
 name          = "websockets"
 readme        = "README.md"
 repository    = "https://github.com/imranmaj/websockets"
-version       = "0.3.0"
+version       = "0.4.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -27,13 +27,7 @@ rand_chacha      = "0.2.2"
 regex            = "1.3.9"
 sha-1            = "0.9.1"
 thiserror        = "1.0.20"
-#tokio            = { version = "0.2.21", features = ["tcp", "io-util", "sync"] }
-tokio            = { version = "1.7", features = ["full"] }
-tokio-native-tls = "0.3.0"
-#tokio-native-tls = "0.1.0"
+tokio            = { version = "1.9", features = ["full"] }
+tokio-native-tls = "0.3"
 url              = "2.1.1"
-flume            = "0.10.7"
-
-[dev-dependencies]
-#tokio = { version = "0.2.21", features = ["rt-core", "macros"] }
-tokio = { version = "1.7", features = ["full"] }
+flume            = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,13 @@ rand_chacha      = "0.2.2"
 regex            = "1.3.9"
 sha-1            = "0.9.1"
 thiserror        = "1.0.20"
-tokio            = { version = "0.2.21", features = ["tcp", "io-util", "sync"] }
-tokio-native-tls = "0.1.0"
+#tokio            = { version = "0.2.21", features = ["tcp", "io-util", "sync"] }
+tokio            = { version = "1.7", features = ["full"] }
+tokio-native-tls = "0.3.0"
+#tokio-native-tls = "0.1.0"
 url              = "2.1.1"
+flume            = "0.10.7"
 
 [dev-dependencies]
-tokio = { version = "0.2.21", features = ["rt-core", "macros"] }
+#tokio = { version = "0.2.21", features = ["rt-core", "macros"] }
+tokio = { version = "1.7", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license       = "MIT"
 name          = "websockets"
 readme        = "README.md"
 repository    = "https://github.com/imranmaj/websockets"
-version       = "0.2.0"
+version       = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -27,7 +27,7 @@ rand_chacha      = "0.2.2"
 regex            = "1.3.9"
 sha-1            = "0.9.1"
 thiserror        = "1.0.20"
-tokio            = { version = "0.2.21", features = ["tcp", "io-util"] }
+tokio            = { version = "0.2.21", features = ["tcp", "io-util", "sync"] }
 tokio-native-tls = "0.1.0"
 url              = "2.1.1"
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ This project is licensed under the MIT license.
 ## Credits
 
 * Thank you to [@thsioutas](https://github.com/thsioutas) for adding support for custom TLS configuration
+* Thank you to [@secana](https://github.com/secana) for making the write half `Send`

--- a/src/websocket/builder.rs
+++ b/src/websocket/builder.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 use std::fmt::{Debug, Error as FmtError, Formatter};
-use std::sync::mpsc;
+use tokio::sync::mpsc;
 
 use native_tls::{
     TlsConnector as NativeTlsTlsConnector, TlsConnectorBuilder as NativeTlsTlsConnectorBuilder,
@@ -40,6 +40,7 @@ pub struct WebSocketBuilder {
     additional_handshake_headers: Vec<(String, String)>,
     subprotocols: Vec<String>,
     tls_connector_builder: NativeTlsTlsConnectorBuilder,
+    recv_buffer: usize,
 }
 
 impl Debug for WebSocketBuilder {
@@ -54,6 +55,7 @@ impl WebSocketBuilder {
             additional_handshake_headers: Vec::new(),
             subprotocols: Vec::new(),
             tls_connector_builder: NativeTlsTlsConnector::builder(),
+            recv_buffer: 100,
         }
     }
 
@@ -83,7 +85,7 @@ impl WebSocketBuilder {
             _ => return Err(WebSocketError::SchemeError),
         };
         let (read_half, write_half) = io::split(stream);
-        let (sender, receiver) = mpsc::channel();
+        let (sender, receiver) = mpsc::channel(self.recv_buffer);
         let mut ws = WebSocket {
             read_half: WebSocketReadHalf {
                 stream: BufReader::new(read_half),
@@ -115,6 +117,13 @@ impl WebSocketBuilder {
                 Err(e)
             }
         }
+    }
+
+    /// Change the buffer size for the receiver channel.
+    /// Default size is 100.
+    pub fn recv_buffer(&mut self, buffer: usize) -> &mut Self {
+        self.recv_buffer = buffer;
+        self
     }
 
     /// Adds a header to be sent in the WebSocket handshake.

--- a/src/websocket/split.rs
+++ b/src/websocket/split.rs
@@ -1,5 +1,6 @@
-use tokio::sync::mpsc::{Receiver, Sender};
+//use tokio::sync::mpsc::{Receiver, Sender};
 
+use flume::{Receiver, Sender};
 use rand_chacha::ChaCha20Rng;
 use tokio::io::{AsyncWriteExt, BufReader, BufWriter, ReadHalf, WriteHalf};
 
@@ -44,7 +45,7 @@ impl WebSocketReadHalf {
                     payload: payload.clone(),
                 };
                 self.sender
-                    .send(Event::SendPongFrame(pong)).await
+                    .send(Event::SendPongFrame(pong))
                     .map_err(|_e| WebSocketError::ChannelError)?;
             }
             // echo close frame and shutdown (https://tools.ietf.org/html/rfc6455#section-1.4)
@@ -55,7 +56,7 @@ impl WebSocketReadHalf {
                         .map(|(status_code, _reason)| (status_code.clone(), String::new())),
                 };
                 self.sender
-                    .send(Event::SendCloseFrameAndShutdown(close)).await
+                    .send(Event::SendCloseFrameAndShutdown(close))
                     .map_err(|_e| WebSocketError::ChannelError)?;
             }
             _ => (),

--- a/src/websocket/split.rs
+++ b/src/websocket/split.rs
@@ -1,5 +1,3 @@
-//use tokio::sync::mpsc::{Receiver, Sender};
-
 use flume::{Receiver, Sender};
 use rand_chacha::ChaCha20Rng;
 use tokio::io::{AsyncWriteExt, BufReader, BufWriter, ReadHalf, WriteHalf};
@@ -220,5 +218,18 @@ impl WebSocketWriteHalf {
     pub async fn send_pong(&mut self, payload: Option<Vec<u8>>) -> Result<(), WebSocketError> {
         // https://tools.ietf.org/html/rfc6455#section-5.5.3
         self.send(Frame::Pong { payload }).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assert_send_sync()
+    where
+        WebSocketReadHalf: Send + Sync,
+        WebSocketWriteHalf: Send + Sync,
+    {
     }
 }

--- a/src/websocket/split.rs
+++ b/src/websocket/split.rs
@@ -1,4 +1,4 @@
-use std::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender};
 
 use rand_chacha::ChaCha20Rng;
 use tokio::io::{AsyncWriteExt, BufReader, BufWriter, ReadHalf, WriteHalf};
@@ -44,7 +44,7 @@ impl WebSocketReadHalf {
                     payload: payload.clone(),
                 };
                 self.sender
-                    .send(Event::SendPongFrame(pong))
+                    .send(Event::SendPongFrame(pong)).await
                     .map_err(|_e| WebSocketError::ChannelError)?;
             }
             // echo close frame and shutdown (https://tools.ietf.org/html/rfc6455#section-1.4)
@@ -55,7 +55,7 @@ impl WebSocketReadHalf {
                         .map(|(status_code, _reason)| (status_code.clone(), String::new())),
                 };
                 self.sender
-                    .send(Event::SendCloseFrameAndShutdown(close))
+                    .send(Event::SendCloseFrameAndShutdown(close)).await
                     .map_err(|_e| WebSocketError::ChannelError)?;
             }
             _ => (),

--- a/src/websocket/stream.rs
+++ b/src/websocket/stream.rs
@@ -1,9 +1,9 @@
 use native_tls::TlsConnector as NativeTlsTlsConnector;
-use tokio::net::TcpStream;
 use std::io::Error as IoError;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
 use tokio_native_tls::{TlsConnector as TokioTlsConnector, TlsStream};
 
 use crate::error::WebSocketError;

--- a/src/websocket/stream.rs
+++ b/src/websocket/stream.rs
@@ -1,9 +1,9 @@
 use native_tls::TlsConnector as NativeTlsTlsConnector;
+use tokio::net::TcpStream;
 use std::io::Error as IoError;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::TcpStream;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_native_tls::{TlsConnector as TokioTlsConnector, TlsStream};
 
 use crate::error::WebSocketError;
@@ -52,8 +52,8 @@ impl AsyncRead for Stream {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize, IoError>> {
+        buf: &mut ReadBuf,
+    ) -> Poll<Result<(), std::io::Error>> {
         match self.get_mut() {
             Self::Plain(tcp_stream) => Pin::new(tcp_stream).poll_read(cx, buf),
             Self::Tls(tls_stream) => Pin::new(tls_stream).poll_read(cx, buf),


### PR DESCRIPTION
Hi! First, many thanks for creating this library. I tried many websocket libraries and this was the easiest to use and best documented.

While using your library in a bigger project with a lot of multi threading, I hit the problem that `std::sync::mpsc::Receiver` is not `Send` and cannot be shared between threads. No matter how many `Arc` and `Mutex` I threw at it. The fix is surprisingly simple, just use `tokio::sync::mpsc` instead of `std::sync::mpsc`. Now, the `Receiver` implements `Send` and works fine in a new thread.

All tests are still successful and I tested it in my application with many different use-cases without any problem. I would appreciate if you approve this PR and release a new version on crates.io.

Kind regards,
 secana